### PR TITLE
Add Nix flake for packaging and module

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,61 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1751011381,
+        "narHash": "sha256-krGXKxvkBhnrSC/kGBmg5MyupUUT5R6IBCLEzx9jhMM=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "30e2e2857ba47844aa71991daa6ed1fc678bcbb7",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,26 @@
+{
+  description = "Interactive Apex Legends map as a Nix flake";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+    flake-utils.url = "github:numtide/flake-utils";
+  };
+
+  outputs = { self, nixpkgs, flake-utils }:
+    flake-utils.lib.eachDefaultSystem (system:
+      let
+        pkgs = import nixpkgs { inherit system; };
+        interactive-apex-map = pkgs.callPackage ./nix/package.nix { };
+      in
+      {
+        packages = {
+          interactive-apex-map = interactive-apex-map;
+          default = interactive-apex-map;
+        };
+      }) // {
+      nixosModules = {
+        interactive-apex-map = import ./nix/module.nix;
+        default = import ./nix/module.nix;
+      };
+    };
+}

--- a/nix/module.nix
+++ b/nix/module.nix
@@ -1,0 +1,50 @@
+{ lib, config, ... }:
+
+let
+  cfg = config.services.interactive-apex-map;
+in
+{
+  options.services.interactive-apex-map = {
+    enable = lib.mkEnableOption "Serve the Interactive Apex Map via nginx";
+
+    package = lib.mkOption {
+      type = lib.types.package;
+      description = "Package that contains the static site (must include index.html).";
+    };
+
+    domain = lib.mkOption {
+      type = lib.types.str;
+      default = "localhost";
+      description = "Hostname or domain for the virtual host.";
+    };
+
+    port = lib.mkOption {
+      type = lib.types.int;
+      default = 8080;
+      description = "TCP port nginx should listen on.";
+    };
+
+    openFirewall = lib.mkEnableOption
+      "Open the firewall for the interactive-apex-map port";
+  };
+
+  config = lib.mkIf cfg.enable {
+    assertions = [{
+      assertion = cfg.package != null;
+      message = "services.interactive-apex-map.package must be set!";
+    }];
+
+    networking.firewall.allowedTCPPorts =
+      lib.mkIf cfg.openFirewall [ cfg.port ];
+
+    services.nginx = {
+      enable = true;
+
+      virtualHosts."${cfg.domain}" = {
+        listen = [{ addr = "0.0.0.0"; port = cfg.port; }];
+        root = cfg.package;
+        extraConfig = "index  index.html;";
+      };
+    };
+  };
+}

--- a/nix/package.nix
+++ b/nix/package.nix
@@ -1,0 +1,21 @@
+{ lib, pkgs, src ? ./.. }:
+
+pkgs.stdenv.mkDerivation {
+  pname = "interactive-apex-map";
+  version = "2025-05-26";
+
+  inherit src;
+  dontBuild = true;
+
+  installPhase = ''
+    runHook preInstall
+    cp -rT "$src" "$out"
+    runHook postInstall
+  '';
+
+  meta = with lib; {
+    description = "Interactive Apex Legends map (static site)";
+    license = licenses.mit;
+    platforms = platforms.all;
+  };
+}


### PR DESCRIPTION
## Summary
- package the interactive site as `interactive-apex-map`
- expose a NixOS module for serving it via nginx
- include `flake.lock` for reproducible evaluation

## Testing
- `nix --experimental-features 'nix-command flakes' flake show`
- `nix --experimental-features 'nix-command flakes' build .#interactive-apex-map -o result`

------
https://chatgpt.com/codex/tasks/task_e_6860516e2094832797605456f322db91